### PR TITLE
Minor wording fixes

### DIFF
--- a/minor-wording-fixes
+++ b/minor-wording-fixes
@@ -56,7 +56,7 @@ The four parties involved in this technology are:
 The data consumed by the user agent to support private click measurement is:
 
 : <dfn>attribution source id</dfn>
-:: An [=eight-bit decimal value=] identifying the content that was clicked to navigate to the destination. This means support for 255 unique pieces of content, such as ads, per click destination on the click source. Example: `merchant.example` can run up to 255 concurrent ad campaigns on `search.example`. The valid decimal values are 0 to 255.
+:: An [=eight-bit decimal value=] identifying the content that was clicked to navigate to the destination. This means support for 255 unique pieces of content, such as ads, per attribution destination on the click source. Example: `merchant.example` can run up to 255 concurrent ad campaigns on `search.example`. The valid decimal values are 0 to 255.
 : <dfn>trigger data</dfn>
 :: A [=four-bit decimal value=] encoding the user action that triggers the attribution. This value may encode things like specific steps in a sales funnel or the value of the sale in buckets, such as less than $10, between $10 and $50, between $51 and $200, above $200, and so on. The valid decimal values are 00 to 15.
 : <dfn>optional trigger priority</dfn>
@@ -79,7 +79,7 @@ A high level example of a scenario where the described technology is intended to
     - What the [=attribution source id=] is.
 4. The user agent navigates and takes note that the user landed on the intended [=attribution destination website=].
 5. The user's activity on the [=attribution destination website=] leads to a [=triggering event=].
-6. A third-party HTTP request is made on the [=click source website=] to `​https://search.example/.well-known/private-click-measurement/trigger-attribution/` with [=trigger data=].
+6. A third-party HTTP request is made on the [=attribution destination website=] to `​https://search.example/.well-known/private-click-measurement/trigger-attribution/` with [=trigger data=].
 7. The user agent checks for stored clicks for the [=click source-attribute-on pair=] and if there's a hit, makes or schedules an HTTP POST request to `​https://search.example/.well-known/private-click-measurement/report-attribution/` with the corresponding [=attribution report=].
 
     ISSUE: One thing to consider here is whether there should be an option to send the [=attribution report=] to the [=attribution destination website=] too.


### PR DESCRIPTION
If I'm reading this right, the third-party request to trigger attribution is made from the attribution destination website rather than click source website.

Additionally, replacing "click destination" with "attribution destination" to match the term used throughout the spec.